### PR TITLE
Add static linking to boost libraries

### DIFF
--- a/gsi/Makefile
+++ b/gsi/Makefile
@@ -19,6 +19,10 @@ EXTRALIBS = -lglobus_gss_assist$(GSI_INSTALL_TYPE2) \
             -lcrypto \
 	    -lglobus_common$(GSI_INSTALL_TYPE2) \
 	    -lglobus_callout$(GSI_INSTALL_TYPE2) \
+	    -L/usr/lib/irods/externals \
+	    -lboost_chrono -lboost_date_time -lboost_filesystem \
+	    -lboost_iostreams -lboost_program_options -lboost_regex \
+	    -lboost_system -lboost_thread \
 	    -lltdl$(GSI_INSTALL_TYPE2) \
 		/usr/lib/libirods_client_api_table.a \
                 /usr/lib/libirods_client_plugins.a


### PR DESCRIPTION
to enable plugin module to be self-contained with respect to boost