### PR TITLE
downgrading gsi (4-2-stable) 

### DIFF
--- a/irods_consortium_continuous_integration_test_hook.py
+++ b/irods_consortium_continuous_integration_test_hook.py
@@ -13,7 +13,7 @@ import irods_python_ci_utilities
 
 
 def get_test_prerequisites_apt():
-    return 'globus-toolkit-repo_latest_all.deb'
+    return 'globus-toolkit-repo_6.0.15_all.deb'
 
 def get_test_prerequisites_yum():
     return 'globus-toolkit-repo-latest.noarch.rpm'


### PR DESCRIPTION
globus latest package does not support ubuntu 14